### PR TITLE
Set router basename from Vite env

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,19 +25,22 @@ const queryClient = new QueryClient({
   },
 });
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <App />,
-    children: [
-      { index: true, element: <DashboardPage /> },    // ← Dashboard is the home
-      { path: "planets", element: <PlanetsPage /> },
-      { path: "visualization", element: <VisualizationPage /> },
-      { path: "diagnostics", element: <DiagnosticsPage /> },
-      { path: "admin/deleted", element: <AdminDeletedPage /> },
-    ],
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <App />,
+      children: [
+        { index: true, element: <DashboardPage /> },    // ← Dashboard is the home
+        { path: "planets", element: <PlanetsPage /> },
+        { path: "visualization", element: <VisualizationPage /> },
+        { path: "diagnostics", element: <DiagnosticsPage /> },
+        { path: "admin/deleted", element: <AdminDeletedPage /> },
+      ],
+    },
+  ],
+  { basename: import.meta.env.BASE_URL }
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- configure the React Router browser router to read the base name from Vite's injected BASE_URL

## Testing
- pnpm dev -- --host --clearScreen=false
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d813bc79d0832aa4962a2b2861a5e5