### PR TITLE
Fix build failure when GITHUB_REPOSITORY env is unavailable

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,13 @@ export default defineConfig(({ command }) => {
   const fallbackRepositoryPath =
     typeof pkg.name === 'string' ? pkg.name : undefined
 
+  const { process: nodeProcess } = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> }
+  }
+
   const repo =
-    process.env.GITHUB_REPOSITORY?.split('/')?.[1] ?? fallbackRepositoryPath
+    nodeProcess?.env?.GITHUB_REPOSITORY?.split('/')?.[1] ??
+    fallbackRepositoryPath
 
   return {
     base: command === 'serve' ? '/' : repo ? `/${repo}/` : '/',


### PR DESCRIPTION
## Summary
- guard access to Node-specific environment variables in the Vite config so the build works without Node type definitions

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d8286f9148832aa2243b1eccea41ba