### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,52 +6,41 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: deploy-pages
+  cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build project
+      - name: Build
         run: pnpm build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ pnpm preview
 
 Build artefacts output to `dist/` and can be served by any static host or reverse proxy configured to forward API calls to the backend.
 
+### GitHub Pages Deployment
+
+- Push the repository to GitHub and enable **GitHub Pages** for the `gh-pages` branch in the repository settings ("Pages" section).
+- The included [`deploy.yml`](.github/workflows/deploy.yml) workflow runs on every push to `main` (or via the "Run workflow" button). It performs `pnpm install`, `pnpm build`, and publishes the generated `dist/` folder to the `gh-pages` branch using [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages).
+- On the first run, the workflow creates the `gh-pages` branch automatically (`force_orphan: true`). Subsequent runs overwrite it with the latest production bundle.
+- Local builds (`pnpm build`) remain available in `dist/` if you prefer to deploy manually.
+
 ## Application Structure
 
 ```


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds with pnpm and deploys the dist/ folder to the gh-pages branch using peaceiris/actions-gh-pages
- document how to enable GitHub Pages and leverage the workflow for automated deployments

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d829d27d18832a812b662a966e15b0