### PR TITLE
Fix pnpm setup for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,11 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          standalone: true
+      - name: Enable Corepack
+        run: corepack enable
 
+      - name: Use pnpm 9
+        run: corepack use pnpm@9.14.4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@9.14.4",
+  "engines": {
+    "node": ">=20",
+    "pnpm": ">=9"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- declare the expected pnpm release and Node engine requirements in package.json
- update the deployment workflow to enable Corepack and activate pnpm before running install/build steps

## Testing
- pnpm lint *(fails: Corepack cannot download pnpm@9.14.4 due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82bb5f008832a826de463e9a5800c