### PR TITLE
Ensure pnpm is provisioned through Corepack in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,11 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          standalone: true
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Activate pnpm
+        run: corepack prepare pnpm@10.5.2 --activate
 
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.5.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- declare the intended pnpm version in package.json so Corepack can provision it automatically
- update the deploy workflow to enable Corepack and activate the pinned pnpm release before running pnpm commands

## Testing
- pnpm lint *(fails: existing lint errors in src/pages/DashboardPage.tsx and src/pages/PlanetsPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d82bb5f008832a826de463e9a5800c