### PR TITLE
Ensure pnpm is provisioned via Corepack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,11 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          standalone: true
+      - name: Enable Corepack
+        run: corepack enable
 
+      - name: Prepare pnpm
+        run: corepack prepare pnpm@9.15.4 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -24,8 +24,15 @@ Modern front-end for the Exoplanet catalogue service. The application gives oper
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 9+ (via [Corepack](https://nodejs.org/docs/latest/api/corepack.html))
 - Running instance of the Exoplanet FastAPI backend (or an accessible deployment URL)
+
+> Enable Corepack once per environment so the matching pnpm version is downloaded automatically:
+>
+> ```bash
+> corepack enable
+> corepack prepare pnpm@9.15.4 --activate
+> ```
 
 ### Install
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- enable Corepack in the deployment workflow so pnpm is provisioned automatically
- document Corepack activation steps in the README and pin the pnpm version in package.json

## Testing
- not run (Corepack download requires external network access)


------
https://chatgpt.com/codex/tasks/task_e_68d82bb5f008832a826de463e9a5800c